### PR TITLE
ignore comments and split by whitespace instead of single space

### DIFF
--- a/xyz-to-obj.py
+++ b/xyz-to-obj.py
@@ -18,8 +18,9 @@ with open(output_file, 'a') as output_file:
 	with open(input_file) as input_file:
 		for i, line in enumerate(input_file):
 			n = i*8
+			if line.startswith("#"): continue # ignore comments in xyz files
+			line = line.strip().split() # get rid of leading and trailing white space, then split by white space
 
-			line = line.split(' ')
 			x = float(line[0])
 			y = float(line[1])
 			z = float(line[2])


### PR DESCRIPTION
really useful code that was also simple to use. Just wanted to submit a pull request to help improve handling .xyz files that had comments in it denoted by "#" and also separated x, y, and z values by a whitespace instead of a single space. As seen in [https://people.math.sc.edu/Burkardt/data/xyz/xyz.html](https://people.math.sc.edu/Burkardt/data/xyz/xyz.html). 

Thanks for sharing the useful code!